### PR TITLE
Added max_participants = 6 in activity.info

### DIFF
--- a/activity/activity.info
+++ b/activity/activity.info
@@ -4,6 +4,7 @@ bundle_id = org.laptop.AbiWordActivity
 exec = sugar-activity AbiWordActivity.AbiWordActivity
 icon = activity-write
 activity_version = 97
+max_participants = 6
 show_launcher = 1
 mime_types = text/rtf;text/plain;application/x-abiword;text/x-xml-abiword;application/msword;application/rtf;application/xhtml+xml;text/html;application/vnd.oasis.opendocument.text
 license = GPLv2+


### PR DESCRIPTION
This is a required property as for without max_participants set in activity.info for invting other user for sharing
The condition in jarabe.view.buddymenu.py #L186 is not satisfied as max_participants is considered 0 when prop not set in activity.info
link #L186 --> https://goo.gl/SoqYZW