### PR TITLE
Add buttons to assist merge and split of table cells

### DIFF
--- a/toolbar.py
+++ b/toolbar.py
@@ -268,10 +268,22 @@ class InsertToolbar(Gtk.Toolbar):
             'clicked', self._table_delete_cols_cb)
         self.insert(self._table_delete_cols, -1)
 
+        self._merge_cells = ToolButton('format-columns-single')
+        self._merge_cells.set_tooltip(_('Merge Cells'))
+        self._merge_cells_id = self._merge_cells.connect(
+            'clicked', self._merge_cells_cb)
+        self.insert(self._merge_cells, -1)
+
+        self._split_cells = ToolButton('format-columns-double')
+        self._split_cells.set_tooltip(_('Split Cells'))
+        self._split_cells_id = self._split_cells.connect(
+            'clicked', self._split_cells_cb)
+        self.insert(self._split_cells, -1)
+
         self.show_all()
 
         self._abiword_canvas.connect('table-state', self._isTable_cb)
-        #self._abiword_canvas.connect('image-selected',
+        # self._abiword_canvas.connect('image-selected',
         #       self._image_selected_cb)
 
     def _table_btn_clicked_cb(self, button):
@@ -292,12 +304,19 @@ class InsertToolbar(Gtk.Toolbar):
     def _table_delete_cols_cb(self, button):
         self._abiword_canvas.invoke_ex('deleteColumns', '', 0, 0)
 
+    def _merge_cells_cb(self, button):
+        self._abiword_canvas.invoke('mergeCells')
+
+    def _split_cells_cb(self, button):
+        self._abiword_canvas.invoke('splitCells')
+
     def _isTable_cb(self, abi, b):
         self._table_rows_after.set_sensitive(b)
         self._table_delete_rows.set_sensitive(b)
         self._table_cols_after.set_sensitive(b)
         self._table_delete_cols.set_sensitive(b)
-
+        self._merge_cells.set_sensitive(b)
+        self._split_cells.set_sensitive(b)
 
 class ViewToolbar(Gtk.Toolbar):
 


### PR DESCRIPTION
Continuing #11 
**Files Changed**
1) `toolbar.py`

**Updates**
1) We can merge and split table cells, without issues.

I thank @ezequielpereira for his earlier contribution as a pull request. I have tested the changes on Ubuntu 18.04, Sugar v0.112