### PR TITLE
flake8 fixes

### DIFF
--- a/AbiWordActivity.py
+++ b/AbiWordActivity.py
@@ -53,10 +53,7 @@ from widgets import ExportButtonFactory
 from widgets import DocumentView
 from speechtoolbar import SpeechToolbar
 from sugar3.graphics.objectchooser import ObjectChooser
-try:
-    from sugar3.graphics.objectchooser import FILTER_TYPE_GENERIC_MIME
-except:
-    FILTER_TYPE_GENERIC_MIME = 'generic_mime'
+from sugar3.graphics.objectchooser import FILTER_TYPE_GENERIC_MIME
 
 logger = logging.getLogger('write-activity')
 
@@ -460,13 +457,9 @@ class AbiWordActivity(activity.Activity):
             'text/plain' in mime_parents
 
     def __image_cb(self, button, floating=False):
-        try:
-            chooser = ObjectChooser(self, what_filter='Image',
-                                    filter_type=FILTER_TYPE_GENERIC_MIME,
-                                    show_preview=True)
-        except:
-            # for compatibility with older versions
-            chooser = ObjectChooser(self, what_filter='Image')
+        chooser = ObjectChooser(self, what_filter='Image',
+                                filter_type=FILTER_TYPE_GENERIC_MIME,
+                                show_preview=True)
 
         try:
             result = chooser.run()

--- a/fontcombobox.py
+++ b/fontcombobox.py
@@ -248,8 +248,8 @@ class FontSize(Gtk.ToolItem):
         hbox.pack_start(self._size_up, False, False, 5)
 
         radius = 2 * subcell_size
-        theme_up = b"GtkButton {border-radius:0px %dpx %dpx 0px;}" % (radius,
-                                                                     radius)
+        theme_up = b"GtkButton {border-radius:0px %dpx %dpx 0px;}" % \
+                   (radius, radius)
         css_provider_up = Gtk.CssProvider()
         css_provider_up.load_from_data(theme_up)
 
@@ -257,8 +257,8 @@ class FontSize(Gtk.ToolItem):
         style_context.add_provider(css_provider_up,
                                    Gtk.STYLE_PROVIDER_PRIORITY_USER)
 
-        theme_down = b"GtkButton {border-radius: %dpx 0px 0px %dpx;}" % (radius,
-                                                                        radius)
+        theme_down = b"GtkButton {border-radius: %dpx 0px 0px %dpx;}" % \
+                     (radius, radius)
         css_provider_down = Gtk.CssProvider()
         css_provider_down.load_from_data(theme_down)
         style_context = self._size_down.get_style_context()

--- a/gridcreate.py
+++ b/gridcreate.py
@@ -134,6 +134,7 @@ class GridCreateTest(Gtk.Window):
     def __create_table(self, grid_creator, rows, columns):
         print('rows %d columns %d' % (rows, columns))
 
+
 if __name__ == '__main__':
     GridCreateTest()
     Gtk.main()

--- a/widgets.py
+++ b/widgets.py
@@ -19,10 +19,7 @@ from gettext import gettext as _
 import logging
 
 import gi
-try:
-    gi.require_version('Abi', '2.9')
-except:
-    gi.require_version('Abi', '3.0')
+gi.require_version('Abi', '3.0')
 from gi.repository import Abi
 from gi.repository import GLib
 
@@ -212,12 +209,12 @@ class DocumentView(Abi.Widget):
         self.connect('size-allocate', self.__size_allocate_cb)
         try:
             self.connect('request-clear-area', self.__request_clear_area_cb)
-        except:
+        except ImportError:
             logging.debug('EXCEPTION: request-clear-area signal not available')
 
         try:
             self.connect('unset-clear-area', self.__unset_clear_area_cb)
-        except:
+        except ImportError:
             logging.debug('EXCEPTION: unset-clear-area signal not available')
 
         self.osk_changed = False


### PR DESCRIPTION
- after porting to Python 3 we know that Sugar 0.116 or later will be
  used, so no need to support older toolkits.