### PR TITLE
 Fix temporary image file cleanup when pasting from clipboard

### DIFF
--- a/toolbar.py
+++ b/toolbar.py
@@ -160,7 +160,8 @@ class EditToolbar(Gtk.Toolbar):
                 px_file.write(data)
                 px_file.close()
                 self._abiword_canvas.insert_image(file_path, False)
-
+                if os.path.exists(file_path):
+                   os.unlink(file_path)
         elif clipboard.wait_is_uris_available():
             selection = clipboard.wait_for_uris()
             if selection is not None:


### PR DESCRIPTION
This PR fixes an issue where a temporary image file created during
clipboard image paste was not properly cleaned up.

The change ensures the temporary file descriptor is closed and the
temporary file is deleted after inserting the image.
