### PR TITLE
fix: check internet connection before showing chat sidebar

### DIFF
--- a/AbiWordActivity.py
+++ b/AbiWordActivity.py
@@ -267,9 +267,10 @@ class AbiWordActivity(activity.Activity):
         if self.chat_sidebar.get_visible():
             self.chat_sidebar.toggle_visibility()
         else:
-            self.chat_sidebar.toggle_visibility()
             if not self.check_internet_connection():
                 self._show_no_internet_dialog()
+                return
+            self.chat_sidebar.toggle_visibility()
 
     def _show_no_internet_dialog(self):
         dialog = Gtk.MessageDialog(


### PR DESCRIPTION
## What this fixes

Closes #66

In `_on_chat_button_clicked` (AbiWordActivity.py ~L266), the original
code had a dead if/else branch — both sides called `toggle_visibility()`
identically, meaning the sidebar always opened before the internet check ran.

**Before:**
```python
if self.chat_sidebar.get_visible():
    self.chat_sidebar.toggle_visibility()
else:
    self.chat_sidebar.toggle_visibility()  # dead branch — same as above
    if not self.check_internet_connection():
        self._show_no_internet_dialog()
```

**After:**
```python
if self.chat_sidebar.get_visible():
    self.chat_sidebar.toggle_visibility()
else:
    if not self.check_internet_connection():
        self._show_no_internet_dialog()
        return
    self.chat_sidebar.toggle_visibility()
```

## Changes

- `AbiWordActivity.py` — 3 lines changed, no new dependencies

## Screenshot 
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/b0a8aa18-bf4f-4ad1-8c31-9f6bd068bb92" />
