### PR TITLE
feat: live word count in view toolbar with debounced updates

### DIFF
--- a/toolbar.py
+++ b/toolbar.py
@@ -396,9 +396,23 @@ class ViewToolbar(Gtk.Toolbar):
         self.insert(tool_item, -1)
         tool_item.show()
 
+        separator2 = Gtk.SeparatorToolItem()
+        separator2.set_draw(True)
+        separator2.show()
+        self.insert(separator2, -1)
+
+        self._word_count_label = Gtk.Label(label=_("Words: 0"))
+        self._word_count_label.show()
+        tool_item_wc = Gtk.ToolItem()
+        tool_item_wc.add(self._word_count_label)
+        self.insert(tool_item_wc, -1)
+        tool_item_wc.show()
+
         self._abiword_canvas.connect("page-count", self._page_count_cb)
         self._abiword_canvas.connect("current-page", self._current_page_cb)
         self._abiword_canvas.connect("zoom", self._zoom_cb)
+        self._abiword_canvas.connect("changed", self._update_word_count_cb)
+
 
     def set_zoom_percentage(self, zoom):
         self._zoom_percentage = zoom
@@ -447,6 +461,21 @@ class ViewToolbar(Gtk.Toolbar):
             self._page_spin.set_value(num)
         finally:
             self._page_spin.handler_unblock(self._page_spin_id)
+
+    def _update_word_count_cb(self, canvas, *args):
+        if hasattr(self, "_word_count_timer") and self._word_count_timer:
+            GObject.source_remove(self._word_count_timer)
+        self._word_count_timer = GObject.timeout_add(500, self._do_word_count, canvas)
+
+    def _do_word_count(self, canvas):
+        try:
+            text = canvas.get_content("text/plain", None)[0]
+            count = len(text.split()) if text.strip() else 0
+            self._word_count_label.props.label = _("Words: ") + str(count)
+        except Exception:
+            pass
+        self._word_count_timer = None
+        return False
 
 
 class TextToolbar(Gtk.Toolbar):


### PR DESCRIPTION
## What this adds

Adds a **Words: N** label to the View toolbar that updates automatically
as the user types.

## How it works

- Connects to the `changed` signal on `abiword_canvas`
- Uses a **500ms debounce timer** (`GObject.timeout_add`) — count only
  updates after the user stops typing, not on every keystroke
- Reads document text via `get_content('text/plain')` only after the
  timer fires

## Why a fresh implementation

Two previous PRs attempted this:
- **PR #6 (2015)** by @Daksh — stale, never merged
- **PR #36 (2019)** by @nswarup14 — blocked by @quozl:
  > "Fetching the whole document in order after every change to count
  > the words is very inefficient. Is there a better way?"

This implementation directly addresses that concern with debouncing.
`get_content` is only called once per typing pause, not on every keystroke.

Note: A native `word-count` signal does not exist in this AbiWord build
(confirmed by inspecting `gi.repository.Abi.Widget` signals at runtime).
The `changed` signal with debouncing is the cleanest available approach.( as for my understanding)

## Changes

- `toolbar.py` — 35 lines added, 0 removed

## Testing

- Tested locally on Ubuntu 24.04 with `GDK_BACKEND=x11 sugar-activity3`
- Word count updates correctly ~500ms after stopping typing
- No lag observed during fast typing


## Screeshots 

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/48154c69-2551-4ddb-ac78-e48813b96ae1" />
